### PR TITLE
Use SWT.getPlatform() instead of Platform.PLATFORM

### DIFF
--- a/org.eclipse.swt.chromium/src/org/eclipse/swt/internal/chromium/ResourceExpander.java
+++ b/org.eclipse.swt.chromium/src/org/eclipse/swt/internal/chromium/ResourceExpander.java
@@ -58,7 +58,7 @@ public class ResourceExpander {
         String maybeSubDirPath = subDir != null ? subDir + SEPARATOR : "";       //               e.g:  subdir/  or ""
         String maybeSubDirPathWithPrefix = subDir != null ? SEPARATOR + maybeSubDirPath : ""; //  e.g: /subdir/  or ""
     	final String finalResourceName = mapResourceName ?
-    			System.mapLibraryName(resourceName + "-" + Platform.PLATFORM) // e.g libMyLib-gtk-3826.so
+    			System.mapLibraryName(resourceName + "-" + SWT.getPlatform()) // e.g libMyLib-gtk-3826.so
     			: resourceName;
 
         // 1) Look for the resource in the java/swt library path(s)
@@ -116,7 +116,7 @@ public class ResourceExpander {
                 }
             }
         }
-        throw new UnsatisfiedLinkError("Could not find resource" + resourceName +  (subDir != null ? " (in subdirectory: " + subDir + " )" : ""));
+        throw new UnsatisfiedLinkError("Could not find resource " + finalResourceName +  (subDir != null ? " (in subdirectory: " + subDir + " )" : ""));
     }
     
     /**


### PR DESCRIPTION
... to prevent the compiler from inlining the string constant
Fixes #77